### PR TITLE
Add tests for ConfigFileMapper

### DIFF
--- a/cmd/aserto/main.go
+++ b/cmd/aserto/main.go
@@ -4,15 +4,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
-	"strings"
 
 	"github.com/alecthomas/kong"
 	"github.com/aserto-dev/aserto/pkg/cc"
 	"github.com/aserto-dev/aserto/pkg/cc/clients"
 	"github.com/aserto-dev/aserto/pkg/cc/config"
 	"github.com/aserto-dev/aserto/pkg/cmd"
-	"github.com/aserto-dev/aserto/pkg/filex"
+	"github.com/aserto-dev/aserto/pkg/cmd/conf"
 	"github.com/aserto-dev/aserto/pkg/x"
 	"github.com/pkg/errors"
 )
@@ -41,7 +39,7 @@ func main() {
 			Indenter:            kong.SpaceIndenter,
 			NoExpandSubcommands: false,
 		}),
-		kong.NamedMapper("conf", configFileMapper(configDir)), // attach to tag `type:"conf"`
+		kong.NamedMapper("conf", conf.ConfigFileMapper(configDir)), // attach to tag `type:"conf"`
 		kong.BindTo(serviceOptions, (*cmd.ServiceOptions)(nil)),
 	)
 
@@ -66,64 +64,4 @@ func configOverrider(cli *cmd.CLI) config.Overrider {
 			conf.TenantID = cli.TenantOverride
 		}
 	}
-}
-
-// configFileMapper is a kong.Mapper that resolves config files.
-//
-// When applied to a CLI flag, it attempts to find a configuration file that best matches the specified name using
-// the following rules:
-// 1. If the value is a full or relative path to an existing file, that file is chosen.
-// 2. If the value is a file name (without a path separator) with an extension (e.g. "config.yaml") and a file with that
-//    name exists in the config directory, that file is chosen.
-// 3. If the value is a string without an dot (e.g. "eng") and a file with that name (i.e. "eng.*") exists in the
-//    config directory, that file is chosen. If multiple files match, the first one is chosen and a warning is printed
-//    to stderr.
-type configFileMapper string
-
-func (m configFileMapper) Decode(ctx *kong.DecodeContext, target reflect.Value) error {
-	if target.Kind() != reflect.String {
-		return errors.Errorf(`"conf" type must be applied to a string not %s`, target.Type())
-	}
-
-	var path string
-	if err := ctx.Scan.PopValueInto("file", &path); err != nil {
-		return err
-	}
-
-	if path != "-" {
-		path = m.find(path)
-	}
-
-	target.SetString(path)
-	return nil
-}
-
-func (m configFileMapper) find(path string) string {
-	expanded := kong.ExpandPath(path)
-	if filex.FileExists(expanded) {
-		return expanded
-	}
-
-	if !strings.ContainsRune(path, filepath.Separator) {
-		expanded = filepath.Join(string(m), path)
-		if filepath.Ext(path) != "" {
-			// It's a filename with no path. Look in config directory.
-			if filex.FileExists(expanded) {
-				return expanded
-			}
-		} else if matches, err := filepath.Glob(expanded + ".*"); err == nil && len(matches) > 0 {
-			if len(matches) > 1 {
-				fmt.Fprintf(
-					os.Stderr,
-					"WARNING: The specified configuration ('%s') matches multiple configuration files: %s. Using '%s'",
-					path,
-					matches,
-					matches[0],
-				)
-			}
-			return matches[0]
-		}
-	}
-
-	return path
 }

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,9 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.26.1
 	github.com/spf13/viper v1.9.0
+	github.com/stretchr/testify v1.7.0
 	github.com/zalando/go-keyring v0.1.1
+	github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04
 	google.golang.org/genproto v0.0.0-20220218161850-94dd64e39d7c
 	google.golang.org/grpc v1.44.0
 	google.golang.org/protobuf v1.27.1
@@ -41,6 +43,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/danieljoos/wincred v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v20.10.11+incompatible // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v20.10.11+incompatible // indirect
@@ -101,5 +104,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	rsc.io/letsencrypt v0.0.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -952,6 +952,8 @@ github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f h1
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
 github.com/zalando/go-keyring v0.1.1 h1:w2V9lcx/Uj4l+dzAf1m9s+DJ1O8ROkEHnynonHjTcYE=
 github.com/zalando/go-keyring v0.1.1/go.mod h1:OIC+OZ28XbmwFxU/Rp9V7eKzZjamBJwRzC8UFJH9+L8=
+github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04 h1:qXafrlZL1WsJW5OokjraLLRURHiw0OzKHD/RNdspp4w=
+github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04/go.mod h1:FiwNQxz6hGoNFBC4nIx+CxZhI3nne5RmIOlT/MXcSD4=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=

--- a/pkg/cc/wire.go
+++ b/pkg/cc/wire.go
@@ -5,6 +5,7 @@ package cc
 
 import (
 	"context"
+	"io"
 
 	"github.com/aserto-dev/aserto/pkg/auth0"
 	"github.com/aserto-dev/aserto/pkg/cc/clients"
@@ -15,9 +16,8 @@ import (
 )
 
 var (
-	ccSet = wire.NewSet(
-		context.Background,
-		config.NewConfig,
+	commonSet = wire.NewSet(
+		clui.NewUI,
 
 		GetCacheKey,
 		token.NewCachedToken,
@@ -25,11 +25,23 @@ var (
 		NewAuthSettings,
 		clients.NewClientFactory,
 
-		clui.NewUI,
-
 		wire.Bind(new(clients.Factory), new(*clients.AsertoFactory)),
 		wire.FieldsOf(new(*config.Config), "Services", "Auth"),
 		wire.Struct(new(CommonCtx), "*"),
+	)
+
+	ccSet = wire.NewSet(
+		commonSet,
+
+		context.Background,
+		config.NewConfig,
+	)
+
+	ccTestSet = wire.NewSet(
+		commonSet,
+
+		context.TODO,
+		config.NewTestConfig,
 	)
 )
 
@@ -39,6 +51,15 @@ func BuildCommonCtx(
 	svcOptions *clients.ServiceOptions,
 ) (*CommonCtx, error) {
 	wire.Build(ccSet)
+	return &CommonCtx{}, nil
+}
+
+func BuildTestCtx(
+	configReader io.Reader,
+	overrides config.Overrider,
+	svcOptions *clients.ServiceOptions,
+) (*CommonCtx, error) {
+	wire.Build(ccTestSet)
 	return &CommonCtx{}, nil
 }
 

--- a/pkg/cmd/cli.go
+++ b/pkg/cmd/cli.go
@@ -23,6 +23,7 @@ type CLI struct {
 	Config       ConfigCmd       `cmd:"" aliases:"c" help:"configuration commands"`
 	Version      VersionCmd      `cmd:"" help:"version information"`
 
+	// ConfigFileMapper implements the `type:"conf"` tag.
 	Cfg            string `name:"config" short:"c" type:"conf" env:"ASERTO_ENV" help:"name or path of configuration file"`
 	Verbosity      int    `short:"v" type:"counter" help:"Use to increase output verbosity."`
 	TenantOverride string `name:"tenant" env:"ASERTO_TENANT_ID" help:"tenant id override"`

--- a/pkg/cmd/conf/mapper.go
+++ b/pkg/cmd/conf/mapper.go
@@ -1,0 +1,83 @@
+package conf
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"github.com/aserto-dev/aserto/pkg/filex"
+	"github.com/pkg/errors"
+)
+
+var ConfigNotFoundErr = errors.New("cannot find configuration file")
+
+// ConfigFileMapper is a kong.Mapper that resolves config files.
+//
+// When applied to a CLI flag, it attempts to find a configuration file that best matches the specified name using
+// the following rules:
+// 1. If the value is a full or relative path to an existing file, that file is chosen.
+// 2. If the value is a file name (without a path separator) with an extension (e.g. "config.yaml") and a file with that
+//    name exists in the config directory, that file is chosen.
+// 3. If the value is a string without an dot (e.g. "eng") and a file with that name (i.e. "eng.*") exists in the
+//    config directory, that file is chosen. If multiple files match, the first one is chosen and a warning is printed
+//    to stderr.
+type ConfigFileMapper string
+
+func (m ConfigFileMapper) Decode(ctx *kong.DecodeContext, target reflect.Value) error {
+	if target.Kind() != reflect.String {
+		return errors.Errorf(`"conf" type must be applied to a string not %s`, target.Type())
+	}
+
+	var path string
+	if err := ctx.Scan.PopValueInto("file", &path); err != nil {
+		return err
+	}
+
+	if path != "-" {
+		if resolved, err := m.find(path); err != nil {
+			return err
+		} else {
+			path = resolved
+		}
+	}
+
+	target.SetString(path)
+	return nil
+}
+
+func (m ConfigFileMapper) find(path string) (string, error) {
+	expanded := kong.ExpandPath(path)
+	if filex.FileExists(expanded) {
+		return expanded, nil
+	}
+
+	if strings.ContainsRune(path, filepath.Separator) {
+		return "", errors.Wrap(ConfigNotFoundErr, path)
+	}
+
+	// It's a filename with no path. Look in config directory.
+	expanded = filepath.Join(string(m), path)
+	if filepath.Ext(path) != "" {
+		// It's a filename with an extension. Try to find the file.
+		if filex.FileExists(expanded) {
+			return expanded, nil
+		}
+	} else if matches, err := filepath.Glob(expanded + ".*"); err == nil && len(matches) > 0 {
+		// Its just a name without an extension. Look for a match.
+		if len(matches) > 1 {
+			fmt.Fprintf(
+				os.Stderr,
+				"WARNING: The specified configuration ('%s') matches multiple configuration files: %s. Using '%s'",
+				path,
+				matches,
+				matches[0],
+			)
+		}
+		return matches[0], nil
+	}
+
+	return "", errors.Wrap(ConfigNotFoundErr, path)
+}

--- a/pkg/cmd/conf/mapper_test.go
+++ b/pkg/cmd/conf/mapper_test.go
@@ -1,0 +1,165 @@
+package conf_test
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"github.com/zenizh/go-capturer"
+
+	"github.com/alecthomas/kong"
+	"github.com/aserto-dev/aserto/pkg/cmd/conf"
+)
+
+type testCLI struct {
+	Cfg string `name:"config" short:"c" type:"conf" env:"TEST_ENV"`
+}
+
+func newParser(t *testing.T, cli *testCLI, options ...kong.Option) *kong.Kong {
+	t.Helper()
+
+	parser, err := kong.New(
+		cli,
+		options...,
+	)
+	require.NoError(t, err)
+
+	return parser
+}
+
+type configDir struct {
+	t     *testing.T
+	Dir   string
+	Files []string
+}
+
+func NewConfigDir(t *testing.T, dir string, files ...string) *configDir {
+	t.Helper()
+
+	confDir := &configDir{t, dir, []string{}}
+	confDir.AddEmptyFiles(files...)
+
+	return confDir
+}
+
+func (d *configDir) File() string {
+	d.t.Helper()
+
+	require.Len(d.t, d.Files, 1, "must have exactly one file")
+	return d.FirstFile()
+}
+
+func (d *configDir) FirstFile() string {
+	return d.Files[0]
+}
+
+func (d *configDir) AddEmptyFiles(filenames ...string) {
+	d.t.Helper()
+	for _, name := range filenames {
+		path := filepath.Join(d.Dir, name)
+		f, err := os.Create(path)
+		require.NoError(d.t, err)
+		f.Close()
+
+		d.Files = append(d.Files, path)
+	}
+
+	sort.Strings(d.Files)
+}
+
+type params struct {
+	t          *testing.T
+	configPath string
+	parser     *kong.Kong
+	cli        *testCLI
+}
+
+func TestConfigFileMapper(t *testing.T) {
+	tests := []struct {
+		Name string
+		Run  func(p *params)
+	}{
+		{
+			"File name with extension",
+			func(p *params) {
+				dir := NewConfigDir(p.t, p.configPath, "test.yaml")
+				_, err := p.parser.Parse([]string{"-c", "test.yaml"})
+				require.NoError(p.t, err)
+				require.Equal(p.t, dir.File(), p.cli.Cfg)
+
+			},
+		},
+		{
+			"File name without extension",
+			func(p *params) {
+				dir := NewConfigDir(p.t, p.configPath, "test.yaml")
+				_, err := p.parser.Parse([]string{"-c", "test"})
+				require.NoError(p.t, err)
+				require.Equal(p.t, dir.File(), p.cli.Cfg)
+			},
+		},
+		{
+			"Multiple files with same name",
+			func(p *params) {
+				NewConfigDir(p.t, p.configPath, "test.yaml", "test.json")
+				stderr := capturer.CaptureStderr(func() {
+					_, err := p.parser.Parse([]string{"-c", "test"})
+					require.NoError(p.t, err)
+				})
+				require.Regexp(p.t, `WARNING: The specified configuration \('test'\) matches multiple configuration files.*`, stderr)
+			},
+		},
+		{
+			"File outside config dir",
+			func(p *params) {
+				dir := NewConfigDir(p.t, p.t.TempDir(), "test.yaml")
+				_, err := p.parser.Parse([]string{"-c", dir.File()})
+				require.NoError(p.t, err)
+				require.Equal(p.t, dir.File(), p.cli.Cfg)
+			},
+		},
+		{
+			"File in env var",
+			func(p *params) {
+				dir := NewConfigDir(p.t, p.configPath, "test.yaml")
+				p.t.Setenv("TEST_ENV", "test")
+				_, err := p.parser.Parse([]string{})
+				require.NoError(p.t, err)
+				require.Equal(p.t, dir.File(), p.cli.Cfg)
+			},
+		},
+		{
+			"File doesn't exist",
+			func(p *params) {
+				_, err := p.parser.Parse([]string{"-c", "test"})
+				require.ErrorIs(p.t, errors.Cause(err), conf.ConfigNotFoundErr)
+			},
+		},
+		{
+			"Path doesn't exist",
+			func(p *params) {
+				_, err := p.parser.Parse([]string{"-c", "path/test"})
+				require.ErrorIs(p.t, errors.Cause(err), conf.ConfigNotFoundErr)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(
+			test.Name,
+			func(tt *testing.T) {
+				cli := &testCLI{}
+				tempDir := tt.TempDir()
+				p := newParser(
+					t,
+					cli,
+					kong.NamedMapper("conf", conf.ConfigFileMapper(tempDir)),
+				)
+				test.Run(&params{tt, tempDir, p, cli})
+			},
+		)
+	}
+}


### PR DESCRIPTION
* Move ConfigFileMapper out of main into its own package.
* Add unit tests for ConfigFileMapper.
* Add ability to create CommonCtx using config from an io.Reader so we can test without  having to create a bunch of test config files.