### PR TITLE
Use tenant-id from acmecorp EDS file in local.yaml

### DIFF
--- a/pkg/handlers/dev/install.go
+++ b/pkg/handlers/dev/install.go
@@ -20,8 +20,8 @@ import (
 type InstallCmd struct {
 	TrustCert bool `optional:"" default:"false" help:"add onebox certificate to the system's trusted CAs"`
 
-	ContainerName    string `optional:""  default:"authorizer-onebox" help:"container name"`
-	ContainerVersion string `optional:""  default:"latest" help:"container version" `
+	ImageName    string `optional:""  default:"authorizer-onebox" help:"image name"`
+	ImageVersion string `optional:""  default:"latest" help:"image version" `
 }
 
 func (cmd InstallCmd) Run(c *cc.CommonCtx) error {
@@ -53,10 +53,10 @@ func (cmd InstallCmd) Run(c *cc.CommonCtx) error {
 	}
 
 	return dockerx.DockerWith(map[string]string{
-		"CONTAINER_NAME":    cmd.ContainerName,
-		"CONTAINER_VERSION": cmd.ContainerVersion,
+		"IMAGE_NAME":    cmd.ImageName,
+		"IMAGE_VERSION": cmd.ImageVersion,
 	},
-		"pull", "ghcr.io/aserto-dev/$CONTAINER_NAME:$CONTAINER_VERSION",
+		"pull", "ghcr.io/aserto-dev/$IMAGE_NAME:$IMAGE_VERSION",
 	)
 }
 

--- a/pkg/handlers/dev/start.go
+++ b/pkg/handlers/dev/start.go
@@ -1,8 +1,6 @@
 package dev
 
 import (
-	"fmt"
-	"os"
 	"path"
 
 	"github.com/aserto-dev/aserto/pkg/cc"
@@ -43,7 +41,7 @@ func (cmd *StartCmd) Run(c *cc.CommonCtx) error {
 	}
 
 	if cmd.Name == local {
-		if err := setupLocalRun(c, paths, cmd.SrcPath); err != nil {
+		if err := verifySrcPath(cmd.SrcPath); err != nil {
 			return err
 		}
 	} else if !filex.FileExists(path.Join(paths.Config, cmd.Name+".yaml")) {
@@ -136,35 +134,13 @@ func (cmd *StartCmd) env(paths *localpaths.Paths) map[string]string {
 	}
 }
 
-func setupLocalRun(c *cc.CommonCtx, paths *localpaths.Paths, srcPath string) error {
+func verifySrcPath(srcPath string) error {
 	if srcPath == "" {
 		return errors.Errorf("mode local requires source path argument to be set")
 	}
 
 	if !filex.DirExists(srcPath) {
 		return errors.Errorf("source path directory %s does not exist", srcPath)
-	}
-
-	cfgLocal := paths.LocalConfig()
-	if !filex.FileExists(cfgLocal) {
-		fmt.Fprintf(c.UI.Output(), "creating %s\n", cfgLocal)
-		f, err := os.OpenFile(cfgLocal, os.O_WRONLY|os.O_CREATE, 0600)
-		if err != nil {
-			return errors.Wrapf(err, "creating %s", cfgLocal)
-		}
-
-		if err := WriteConfig(f, configTemplateLocal, &templateParams{TenantID: c.TenantID()}); err != nil {
-			return errors.Wrapf(err, "writing %s", cfgLocal)
-		}
-
-	}
-
-	edsFile := paths.LocalEDS()
-	if !filex.FileExists(edsFile) {
-		fmt.Fprintf(c.UI.Output(), "creating %s\n", edsFile)
-		if err := createDefaultEds(edsFile); err != nil {
-			return errors.Wrap(err, "create default eds")
-		}
 	}
 
 	return nil

--- a/pkg/handlers/dev/templates.go
+++ b/pkg/handlers/dev/templates.go
@@ -8,6 +8,9 @@ type templateParams struct {
 	TenantKey    string
 }
 
+// Tenant ID used in local eds store and onebox console.
+const localTenantID = "5d7cccc6-1657-11ec-a291-00001df0866c"
+
 const configTemplate = templatePreamble + `
 opa:
   instance_id: {{ .TenantID }}

--- a/pkg/handlers/dev/uninstall.go
+++ b/pkg/handlers/dev/uninstall.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/aserto-dev/aserto/pkg/cc"
 	"github.com/aserto-dev/aserto/pkg/dockerx"
@@ -71,7 +72,10 @@ func (cmd UninstallCmd) Run(c *cc.CommonCtx) error {
 
 	if str != "" {
 		fmt.Fprintf(c.UI.Output(), "removing %s\n", "aserto-dev/authorizer-onebox")
-		err = dockerx.DockerRun("rmi", str)
+		images := strings.Split(str, "\n")
+		for _, image := range images {
+			err = dockerx.DockerRun("rmi", image)
+		}
 	}
 
 	return err


### PR DESCRIPTION
This PR:
1. Uses the well-known tenant ID from the acmecorp EDS image in the `local.yaml` config file.
1. Moves the creation of `local.yaml` from `developer start` to `developer install` because it no longer uses the user's tenant ID.
2. Prevents `developer uninstall` from failing if multiple versions of the onebox image are present on the machine. It removes them all.