### PR TITLE
Add optional identity and resource context to authorizer commands

### DIFF
--- a/pkg/handlers/authorizer/decisiontree.go
+++ b/pkg/handlers/authorizer/decisiontree.go
@@ -10,7 +10,7 @@ import (
 type DecisionTreeCmd struct {
 	AuthParams `embed:""`
 	Path       string   `name:"path" help:"policy package to evaluate"`
-	Decisions  []string `name:"decisions" help:"policy decisions to return"`
+	Decisions  []string `name:"decisions" default:"*" help:"policy decisions to return"`
 }
 
 func (cmd *DecisionTreeCmd) Run(c *cc.CommonCtx) error {

--- a/pkg/handlers/authorizer/decisiontree.go
+++ b/pkg/handlers/authorizer/decisiontree.go
@@ -9,8 +9,8 @@ import (
 
 type DecisionTreeCmd struct {
 	AuthParams `embed:""`
-	Path       string
-	Decisions  []string
+	Path       string   `name:"path" help:"policy package to evaluate"`
+	Decisions  []string `name:"decisions" required:"" help:"policy decisions to return"`
 }
 
 func (cmd *DecisionTreeCmd) Run(c *cc.CommonCtx) error {

--- a/pkg/handlers/authorizer/decisiontree.go
+++ b/pkg/handlers/authorizer/decisiontree.go
@@ -8,13 +8,18 @@ import (
 )
 
 type DecisionTreeCmd struct {
-	PolicyID  string `name:"policy_id" required:"" help:"policy id"`
-	Path      string
-	Decisions []string
+	AuthParams `embed:""`
+	Path       string
+	Decisions  []string
 }
 
 func (cmd *DecisionTreeCmd) Run(c *cc.CommonCtx) error {
 	client, err := c.AuthorizerClient()
+	if err != nil {
+		return err
+	}
+
+	resource, err := cmd.ResourceContext()
 	if err != nil {
 		return err
 	}
@@ -25,10 +30,8 @@ func (cmd *DecisionTreeCmd) Run(c *cc.CommonCtx) error {
 			Path:      cmd.Path,
 			Decisions: cmd.Decisions,
 		},
-		IdentityContext: &api.IdentityContext{
-			Identity: "",
-			Type:     api.IdentityType_IDENTITY_TYPE_NONE,
-		},
+		IdentityContext: cmd.IdentityContext(),
+		ResourceContext: resource,
 		Options: &authz.DecisionTreeOptions{
 			PathSeparator: authz.PathSeparator_PATH_SEPARATOR_DOT,
 		},

--- a/pkg/handlers/authorizer/decisiontree.go
+++ b/pkg/handlers/authorizer/decisiontree.go
@@ -10,7 +10,7 @@ import (
 type DecisionTreeCmd struct {
 	AuthParams `embed:""`
 	Path       string   `name:"path" help:"policy package to evaluate"`
-	Decisions  []string `name:"decisions" required:"" help:"policy decisions to return"`
+	Decisions  []string `name:"decisions" help:"policy decisions to return"`
 }
 
 func (cmd *DecisionTreeCmd) Run(c *cc.CommonCtx) error {

--- a/pkg/handlers/authorizer/params.go
+++ b/pkg/handlers/authorizer/params.go
@@ -1,0 +1,59 @@
+package authorizer
+
+import (
+	"encoding/json"
+	"fmt"
+
+	api "github.com/aserto-dev/go-grpc/aserto/api/v1"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type IdentityType string
+
+const (
+	IdentityTypeNone IdentityType = "none"
+	IdentityTypeSub  IdentityType = "sub"
+	IdentityTypeJwt  IdentityType = "jwt"
+)
+
+type AuthParams struct {
+	Identity     string       `name:"identity" help:"caller identity" default:""`
+	IdentityType IdentityType `name:"identity-type" enum:"sub,jwt,none" help:"type of identity [sub|jwt|none]"  default:"none"`
+	Resource     string       `name:"resource" help:"a JSON object to include as resource context"`
+	PolicyID     string       `name:"policy-id" required:"" help:"policy id"`
+}
+
+func (a AuthParams) IdentityContext() *api.IdentityContext {
+	id_type := api.IdentityType_IDENTITY_TYPE_NONE
+	switch a.IdentityType {
+	case IdentityTypeSub:
+		id_type = api.IdentityType_IDENTITY_TYPE_SUB
+	case IdentityTypeJwt:
+		id_type = api.IdentityType_IDENTITY_TYPE_JWT
+	}
+
+	return &api.IdentityContext{
+		Identity: a.Identity,
+		Type:     id_type,
+	}
+}
+
+func (a AuthParams) ResourceContext() (*structpb.Struct, error) {
+	result := &structpb.Struct{}
+
+	if a.Resource != "" {
+		var r interface{}
+		if err := json.Unmarshal([]byte(a.Resource), &r); err != nil {
+			return result, err
+		}
+
+		m, ok := r.(map[string]interface{})
+		if !ok {
+			return result, fmt.Errorf("resource must be a JSON object")
+		}
+
+		return structpb.NewStruct(m)
+	}
+
+	return result, nil
+}

--- a/pkg/handlers/authorizer/params.go
+++ b/pkg/handlers/authorizer/params.go
@@ -24,17 +24,19 @@ type AuthParams struct {
 }
 
 func (a AuthParams) IdentityContext() *api.IdentityContext {
-	id_type := api.IdentityType_IDENTITY_TYPE_NONE
+	var idType api.IdentityType
 	switch a.IdentityType {
 	case IdentityTypeSub:
-		id_type = api.IdentityType_IDENTITY_TYPE_SUB
+		idType = api.IdentityType_IDENTITY_TYPE_SUB
 	case IdentityTypeJwt:
-		id_type = api.IdentityType_IDENTITY_TYPE_JWT
+		idType = api.IdentityType_IDENTITY_TYPE_JWT
+	case IdentityTypeNone:
+		idType = api.IdentityType_IDENTITY_TYPE_NONE
 	}
 
 	return &api.IdentityContext{
 		Identity: a.Identity,
-		Type:     id_type,
+		Type:     idType,
 	}
 }
 

--- a/pkg/handlers/authorizer/query.go
+++ b/pkg/handlers/authorizer/query.go
@@ -10,7 +10,8 @@ import (
 type ExecQueryCmd struct {
 	AuthParams `embed:""`
 	Statement  string `arg:"stmt" name:"stmt" required:"" help:"query statement"`
-	Input      string `name:"input" optional:"" help:"query input context"`
+	Path       string `name:"path" help:"policy package to evaluate"`
+	Input      string `name:"input" help:"query input context"`
 }
 
 func (cmd *ExecQueryCmd) Run(c *cc.CommonCtx) error {
@@ -29,7 +30,8 @@ func (cmd *ExecQueryCmd) Run(c *cc.CommonCtx) error {
 		Input:           cmd.Input,
 		IdentityContext: cmd.IdentityContext(),
 		PolicyContext: &api.PolicyContext{
-			Id: cmd.PolicyID,
+			Id:   cmd.PolicyID,
+			Path: cmd.Path,
 		},
 		ResourceContext: resource,
 		Options: &authz.QueryOptions{

--- a/pkg/handlers/authorizer/query.go
+++ b/pkg/handlers/authorizer/query.go
@@ -5,13 +5,12 @@ import (
 	"github.com/aserto-dev/aserto/pkg/jsonx"
 	authz "github.com/aserto-dev/go-grpc-authz/aserto/authorizer/authorizer/v1"
 	api "github.com/aserto-dev/go-grpc/aserto/api/v1"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type ExecQueryCmd struct {
-	PolicyID  string `name:"policy_id" required:"" help:"policy id"`
-	Statement string `arg:"stmt" name:"stmt" required:"" help:"query statement"`
-	Input     string `name:"input" optional:"" help:"query input context"`
+	AuthParams `embed:""`
+	Statement  string `arg:"stmt" name:"stmt" required:"" help:"query statement"`
+	Input      string `name:"input" optional:"" help:"query input context"`
 }
 
 func (cmd *ExecQueryCmd) Run(c *cc.CommonCtx) error {
@@ -20,17 +19,19 @@ func (cmd *ExecQueryCmd) Run(c *cc.CommonCtx) error {
 		return err
 	}
 
+	resource, err := cmd.ResourceContext()
+	if err != nil {
+		return err
+	}
+
 	resp, err := client.Authorizer.Query(c.Context, &authz.QueryRequest{
-		Query: cmd.Statement,
-		Input: cmd.Input,
-		IdentityContext: &api.IdentityContext{
-			Identity: "",
-			Type:     api.IdentityType_IDENTITY_TYPE_NONE,
-		},
+		Query:           cmd.Statement,
+		Input:           cmd.Input,
+		IdentityContext: cmd.IdentityContext(),
 		PolicyContext: &api.PolicyContext{
 			Id: cmd.PolicyID,
 		},
-		ResourceContext: &structpb.Struct{},
+		ResourceContext: resource,
 		Options: &authz.QueryOptions{
 			Metrics:      false,
 			Instrument:   false,


### PR DESCRIPTION
## New Flags
This adds optional flags to the `aserto authorizer ...` commands to allow passing identity and resource contexts to the authorizer.
```
      --identity=""                caller identity
      --identity-type="none"       type of identity [sub|jwt|none]
      --resource=STRING            a JSON object to include as resource context
```

It allows running more complex evaluations like:
```
aserto authorizer eval-decision --policy-id=<policy_id> --path=<policy_path> --decisions=allowed \
    --identity "auth0|9e86077a-25f5-11ec-bfb1-026579639f8b" --identity-type sub \
    --resource '{"tenant_id": "8e788220-8dcc-11ec-a66c-00e0b7d9882c"}'
```

## Updated Flags
* `--path` and `--decisions` are now required in `aserto authorizer eval-decision`. 
* `aserto authorizer exec-query` can now optionally take a `--path`. It simply populates the `input.policy.path` field making it easier to copy expressions out of policies and execute them in isolation.