### PR TITLE
renamed renaming "onebox" instances to "sidecar"

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ developer
   developer (x) start        start sidecar instance
   developer (x) stop         stop sidecar instance
   developer (x) status       status of sidecar instance
-  developer (x) update       download the latest aserto onebox image
+  developer (x) update       download the latest aserto sidecar image
   developer (x) console      launch web console
   developer (x) configure    configure a policy
-  developer (x) install      install aserto onebox
-  developer (x) uninstall    uninstall aserto onebox, removes all locally
+  developer (x) install      install aserto sidecar
+  developer (x) uninstall    uninstall aserto sidecar, removes all locally
                              installed artifacts
 
 user

--- a/pkg/cc/clients/options.go
+++ b/pkg/cc/clients/options.go
@@ -79,7 +79,7 @@ func (c *optionsBuilder) ConnectionOptions() ([]aserto.ConnectionOption, error) 
 		if err == nil {
 			caCertPathOption = aserto.WithCACertPath(p.Certs.GRPC.CA)
 		} else {
-			log.Println("Unable to locate onebox certificates.", err.Error())
+			log.Println("Unable to locate sidecar certificates.", err.Error())
 		}
 	}
 

--- a/pkg/handlers/dev/certs/trust_darwin.go
+++ b/pkg/handlers/dev/certs/trust_darwin.go
@@ -20,7 +20,7 @@ func AddTrustedCert(certPath string) error {
 	keychain := path.Join(homedir, loginKeychain)
 
 	if err := sh.RunV("security", "add-trusted-cert", "-k", keychain, certPath); err != nil {
-		return errors.Wrap(err, "trusting onebox ca cert")
+		return errors.Wrap(err, "trusting sidecar ca cert")
 	}
 
 	return nil
@@ -41,7 +41,7 @@ func RemoveTrustedCert(certPath string) error {
 
 	fmt.Fprintln(os.Stderr, "Deleting dev certificate...")
 	if err := sh.RunV("security", "delete-certificate", "-c", "authorizer-gateway-ca", "-t", keychain); err != nil {
-		return errors.Wrap(err, "can't remove onebox ca cert")
+		return errors.Wrap(err, "can't remove sidecar ca cert")
 	}
 
 	return nil

--- a/pkg/handlers/dev/certs/trust_linux.go
+++ b/pkg/handlers/dev/certs/trust_linux.go
@@ -32,7 +32,7 @@ func RemoveTrustedCert(certPath string) error {
 	}
 
 	if err := sh.RunV("rm", "-rf", CaCertsDir); err != nil {
-		return errors.Wrap(err, "unable to remove onebox cert")
+		return errors.Wrap(err, "unable to remove sidecar cert")
 	}
 
 	return updateCaCerts()

--- a/pkg/handlers/dev/install.go
+++ b/pkg/handlers/dev/install.go
@@ -13,9 +13,9 @@ import (
 )
 
 type InstallCmd struct {
-	TrustCert bool `optional:"" default:"false" help:"add onebox certificate to the system's trusted CAs"`
+	TrustCert bool `optional:"" default:"false" help:"add sidecar certificate to the system's trusted CAs"`
 
-	ContainerName    string `optional:""  default:"authorizer-onebox" help:"container name"`
+	ContainerName    string `optional:""  default:"sidecar" help:"container name"`
 	ContainerVersion string `optional:""  default:"latest" help:"container version" `
 }
 
@@ -24,18 +24,18 @@ func (cmd InstallCmd) Run(c *cc.CommonCtx) error {
 		if err != nil {
 			return err
 		}
-		color.Yellow("!!! onebox is already running")
+		color.Yellow("!!! sidecar is already running")
 		return nil
 	}
 
-	color.Green(">>> installing onebox...")
+	color.Green(">>> installing sidecar...")
 
 	paths, err := localpaths.Create()
 	if err != nil {
 		return errors.Wrap(err, "failed to create configuration directory")
 	}
 
-	// Create onebox certs if none exist.
+	// Create sidecar certs if none exist.
 	if err := certs.GenerateCerts(c.UI.Output(), c.UI.Err(), paths.Certs.GRPC, paths.Certs.Gateway); err != nil {
 		return errors.Wrap(err, "failed to create dev certificates")
 	}

--- a/pkg/handlers/dev/start.go
+++ b/pkg/handlers/dev/start.go
@@ -24,7 +24,7 @@ type StartCmd struct {
 	Name             string `arg:"" required:"" help:"policy name"`
 	SrcPath          string `optional:"" type:"path" help:"path to source or bundle file"`
 	Interactive      bool   `optional:"" help:"interactive execution mode instead of the default daemon mode"`
-	ContainerName    string `optional:"" default:"authorizer-onebox" help:"container name"`
+	ContainerName    string `optional:"" default:"sidecar" help:"container name"`
 	ContainerVersion string `optional:"" default:"latest" help:"container version" `
 	Hostname         string `optional:"" help:"hostname for docker to set"`
 	DataPath         string `optional:"" type:"path" help:"path for non-ephemeral data storage"`
@@ -35,11 +35,11 @@ func (cmd *StartCmd) Run(c *cc.CommonCtx) error {
 		if err != nil {
 			return err
 		}
-		color.Yellow("!!! onebox is already running")
+		color.Yellow("!!! sidecar is already running")
 		return nil
 	}
 
-	color.Green(">>> starting onebox...")
+	color.Green(">>> starting sidecar...")
 
 	paths, err := localpaths.NewWithDataRoot(cmd.DataPath)
 	if err != nil {

--- a/pkg/handlers/dev/status.go
+++ b/pkg/handlers/dev/status.go
@@ -15,9 +15,9 @@ func (cmd StatusCmd) Run(c *cc.CommonCtx) error {
 		return err
 	}
 	if running {
-		color.Green(">>> onebox is running")
+		color.Green(">>> sidecar is running")
 	} else {
-		color.Yellow(">>> onebox is not running")
+		color.Yellow(">>> sidecar is not running")
 	}
 	return nil
 }

--- a/pkg/handlers/dev/stop.go
+++ b/pkg/handlers/dev/stop.go
@@ -16,7 +16,7 @@ func (cmd StopCmd) Run(c *cc.CommonCtx) error {
 	}
 
 	if running {
-		color.Green(">>> stopping onebox...")
+		color.Green(">>> stopping sidecar...")
 		return dockerx.DockerRun("stop", dockerx.AsertoOne)
 	}
 

--- a/pkg/handlers/dev/uninstall.go
+++ b/pkg/handlers/dev/uninstall.go
@@ -18,7 +18,7 @@ import (
 type UninstallCmd struct{}
 
 func (cmd UninstallCmd) Run(c *cc.CommonCtx) error {
-	color.Green(">>> uninstalling onebox...")
+	color.Green(">>> uninstalling sidecar...")
 
 	var err error
 
@@ -46,11 +46,11 @@ func (cmd UninstallCmd) Run(c *cc.CommonCtx) error {
 	}
 
 	if err = os.RemoveAll(paths.Certs.Root); err != nil {
-		return errors.Wrap(err, "failed to delete onebox certificates")
+		return errors.Wrap(err, "failed to delete sidecar certificates")
 	}
 
 	str, err := dockerx.DockerWithOut(map[string]string{
-		"NAME": "authorizer-onebox",
+		"NAME": "sidecar",
 	},
 		"images",
 		"ghcr.io/aserto-dev/$NAME",
@@ -62,7 +62,7 @@ func (cmd UninstallCmd) Run(c *cc.CommonCtx) error {
 	}
 
 	if str != "" {
-		fmt.Fprintf(c.UI.Output(), "removing %s\n", "aserto-dev/authorizer-onebox")
+		fmt.Fprintf(c.UI.Output(), "removing %s\n", "aserto-dev/sidecar")
 		err = dockerx.DockerRun("rmi", str)
 	}
 

--- a/pkg/handlers/dev/update.go
+++ b/pkg/handlers/dev/update.go
@@ -8,12 +8,12 @@ import (
 )
 
 type UpdateCmd struct {
-	ContainerName    string `optional:""  default:"authorizer-onebox" help:"container name"`
+	ContainerName    string `optional:""  default:"sidecar" help:"container name"`
 	ContainerVersion string `optional:""  default:"latest" help:"container version" `
 }
 
 func (cmd UpdateCmd) Run(c *cc.CommonCtx) error {
-	color.Green(">>> updating onebox...")
+	color.Green(">>> updating sidecar...")
 
 	return dockerx.DockerWith(map[string]string{
 		"CONTAINER_NAME":    cmd.ContainerName,


### PR DESCRIPTION
This PR changes all remaining instances of "onebox" to "sidecar", including the default container image name ("authorizer-onebox" -> "sidecar")
