### PR TITLE
fix tenant switching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,18 +9,18 @@ require (
 	github.com/aserto-dev/go-aserto v0.32.0
 	github.com/aserto-dev/go-decision-logs v0.0.4
 	github.com/aserto-dev/go-grpc v0.8.68
-	github.com/aserto-dev/topaz v0.32.22
+	github.com/aserto-dev/topaz v0.32.23
 	github.com/cli/browser v1.3.0
 	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1
-	github.com/samber/lo v1.46.0
+	github.com/samber/lo v1.47.0
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
 	github.com/zalando/go-keyring v0.2.5
 	github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240812133136-8ffd90a71988
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
 )
@@ -38,7 +38,7 @@ require (
 	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/aserto-dev/aserto-management v0.9.6 // indirect
-	github.com/aserto-dev/azm v0.1.13 // indirect
+	github.com/aserto-dev/azm v0.1.14 // indirect
 	github.com/aserto-dev/certs v0.0.7 // indirect
 	github.com/aserto-dev/errors v0.0.11 // indirect
 	github.com/aserto-dev/go-authorizer v0.20.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/aserto-dev/aserto-management v0.9.6 h1:c03a106uABQIlY4PshlaABwj2RscqsxRa+XDYLp1HQY=
 github.com/aserto-dev/aserto-management v0.9.6/go.mod h1:Bs2AEKP/JGd01usokqq7C4iI6/0smcE6sjm3k3nOfIA=
-github.com/aserto-dev/azm v0.1.13 h1:YXDdU07zuaKr9ENQeRjVCy/7Q6U6r2HF2vEWIbyEXdc=
-github.com/aserto-dev/azm v0.1.13/go.mod h1:gMdMvXNcdvlzDXjEG3Tt0vLCarTAVeROa2T48FwkOD4=
+github.com/aserto-dev/azm v0.1.14 h1:kIo8xCV7rOJ+NWdDiz5szUm8cyD9LRQqYF2Fu0JQUiM=
+github.com/aserto-dev/azm v0.1.14/go.mod h1:gMdMvXNcdvlzDXjEG3Tt0vLCarTAVeROa2T48FwkOD4=
 github.com/aserto-dev/certs v0.0.7 h1:WsFrHywNE88tgUeDJ2FsV+mgy46QFQvCIYm7c5TNIKE=
 github.com/aserto-dev/certs v0.0.7/go.mod h1:aguR/vIf6cag3O7vaYpJ4Jt1+1DJehBC2Uzto9gxXv8=
 github.com/aserto-dev/errors v0.0.11 h1:CXo+Uwmh09doG2HvL1SC8Fnne8f9VPrGyEQPtogAfyY=
@@ -101,8 +101,8 @@ github.com/aserto-dev/self-decision-logger v0.0.7 h1:Ubv7KDGMJIzWR2jQekAnhb0+HzY
 github.com/aserto-dev/self-decision-logger v0.0.7/go.mod h1:lCuqXg/vr5gt3SvMoZGfOQuKCBP8ar9mih1DOxn0QLI=
 github.com/aserto-dev/service-host v0.0.16 h1:M0Ur9esiFw9gmtiIfW+8mx2wgYOAn4b25G0KLcEKFEE=
 github.com/aserto-dev/service-host v0.0.16/go.mod h1:M3Mn8Zg7zp5U4sK32kclokPX1gi9xoOxJF1EYM67SEY=
-github.com/aserto-dev/topaz v0.32.22 h1:GYAF8JUQ3GZUd9h0RPbg14CnWJjwQNDrQPRjHMaebq4=
-github.com/aserto-dev/topaz v0.32.22/go.mod h1:OZDJmsiyD3SPpg9I0eNtGOZBAkZxnfSSS1hY7IDrGTM=
+github.com/aserto-dev/topaz v0.32.23 h1:VUTlMuw0gFBIY02OGyoGWqF/wphIB6SyQxrT9lJp2Ew=
+github.com/aserto-dev/topaz v0.32.23/go.mod h1:/lmVStEUogcQqHtlNBzYAx46oauOM0aiyvJe1TmSqP8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -496,8 +496,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/samber/lo v1.46.0 h1:w8G+oaCPgz1PoCJztqymCFaKwXt+5cCXn51uPxExFfQ=
-github.com/samber/lo v1.46.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
+github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
+github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
@@ -891,8 +891,8 @@ google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto/googleapis/api v0.0.0-20240812133136-8ffd90a71988 h1:+/tmTy5zAieooKIXfzDm9KiA3Bv6JBwriRN9LY+yayk=
 google.golang.org/genproto/googleapis/api v0.0.0-20240812133136-8ffd90a71988/go.mod h1:4+X6GvPs+25wZKbQq9qyAXrwIRExv7w0Ea6MgZLZiDM=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240812133136-8ffd90a71988 h1:V71AcdLZr2p8dC9dbOIMCpqi4EmRl8wUwnJzXXLmbmc=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240812133136-8ffd90a71988/go.mod h1:Ue6ibwXGpU+dqIcODieyLOcgj7z8+IcskoNIgZxtrFY=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142 h1:e7S5W7MGGLaSu8j3YjdezkZ+m1/Nm0uRVRMEMGk26Xs=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/pkg/cc/cc.go
+++ b/pkg/cc/cc.go
@@ -46,9 +46,9 @@ func NewCommonCtx(tc *topazCC.CommonCtx, configPath config.Path, overrides ...co
 	cacheKey := GetCacheKey(auth)
 	cachedToken := token.Load(cacheKey)
 
-	tenantID := newTenantID(configConfig, cachedToken)
+	configConfig.TenantID = newTenantID(configConfig, cachedToken)
 
-	asertoFactory, err := clients.NewClientFactory(services, tenantID, cachedToken)
+	asertoFactory, err := clients.NewClientFactory(services, cachedToken)
 	if err != nil {
 		return nil, err
 	}
@@ -71,13 +71,12 @@ func NewCommonCtx(tc *topazCC.CommonCtx, configPath config.Path, overrides ...co
 	return commonCtx, nil
 }
 
-func newTenantID(cfg *config.Config, cachedToken *token.CachedToken) clients.TenantID {
+func newTenantID(cfg *config.Config, cachedToken *token.CachedToken) string {
 	id := cfg.TenantID
 	if id == "" {
 		id = cachedToken.TenantID()
 	}
-
-	return clients.TenantID(id)
+	return id
 }
 
 func GetCacheKey(auth *config.Auth) token.CacheKey {

--- a/pkg/cc/cc.go
+++ b/pkg/cc/cc.go
@@ -88,6 +88,14 @@ func newAuthSettings(auth *config.Auth) *auth0.Settings {
 	return auth.GetSettings()
 }
 
+func (ctx *CommonCtx) TenantID() string {
+	tkn, err := ctx.Token()
+	if err != nil {
+		return ""
+	}
+	return tkn.TenantID
+}
+
 func (ctx *CommonCtx) AccessToken() (string, error) {
 	tkn, err := ctx.Token()
 	if err != nil {

--- a/pkg/cc/clients/factory.go
+++ b/pkg/cc/clients/factory.go
@@ -26,19 +26,13 @@ type Factory interface {
 type OptionsBuilder func() ([]client.ConnectionOption, error)
 
 type AsertoFactory struct {
-	tenantID   string
 	svcOptions map[x.Service]OptionsBuilder
 }
 
-type TenantID string
-
 func NewClientFactory(
 	services *x.Services,
-	tenantID TenantID,
 	token *tok.CachedToken,
 ) (*AsertoFactory, error) {
-	tID := string(tenantID)
-
 	defaultEnv := x.DefaultEnvironment()
 
 	options := map[x.Service]OptionsBuilder{}
@@ -47,7 +41,6 @@ func NewClientFactory(
 			service:     svc,
 			options:     services.Get(svc),
 			defaultAddr: defaultEnv.Get(svc).Address,
-			tenantID:    tID,
 			token:       token,
 		}
 
@@ -55,7 +48,6 @@ func NewClientFactory(
 	}
 
 	return &AsertoFactory{
-		tenantID:   tID,
 		svcOptions: options,
 	}, nil
 }

--- a/pkg/cc/clients/factory.go
+++ b/pkg/cc/clients/factory.go
@@ -18,8 +18,6 @@ import (
 )
 
 type Factory interface {
-	TenantID() string
-
 	TenantClient(ctx context.Context) (*tenant.Client, error)
 	DecisionLogsClient(ctx context.Context) (*dl.Client, error)
 	ControlPlaneClient(ctx context.Context) (*cp.Client, error)
@@ -60,10 +58,6 @@ func NewClientFactory(
 		tenantID:   tID,
 		svcOptions: options,
 	}, nil
-}
-
-func (c *AsertoFactory) TenantID() string {
-	return c.tenantID
 }
 
 func (c *AsertoFactory) TenantClient(ctx context.Context) (*tenant.Client, error) {

--- a/pkg/handlers/config/config.go
+++ b/pkg/handlers/config/config.go
@@ -121,7 +121,8 @@ func (cmd *UseConfigCmd) Run(c *cc.CommonCtx) error {
 		if ok {
 			headersMap, ok := serviceMap["headers"].(map[string]interface{})
 			if ok {
-				c.Config.TenantID, ok = headersMap["aserto-tenant-id"].(string)
+				strTenantID, ok := headersMap["aserto-tenant-id"].(string)
+				c.Config.TenantID = strTenantID
 				if !ok {
 					c.Config.TenantID = ""
 				}

--- a/pkg/handlers/config/config.go
+++ b/pkg/handlers/config/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aserto-dev/aserto/pkg/cc"
 	"github.com/aserto-dev/aserto/pkg/cc/config"
 	errs "github.com/aserto-dev/aserto/pkg/cc/errors"
+	"github.com/aserto-dev/aserto/pkg/handlers/user"
 	"github.com/aserto-dev/go-grpc/aserto/api/v1"
 	account "github.com/aserto-dev/go-grpc/aserto/tenant/account/v1"
 	topazConfig "github.com/aserto-dev/topaz/pkg/cc/config"
@@ -143,7 +144,17 @@ func (cmd *UseConfigCmd) Run(c *cc.CommonCtx) error {
 			return errors.Wrapf(errs.ResolveTenantErr, tenantName)
 		}
 
+		token, err := c.Token()
+		if err != nil {
+			return err
+		}
+
 		c.Config.TenantID = tenant[0].Id
+		token.TenantID = tenant[0].Id
+
+		if err := user.SwitchKeyRing(c, token, tenant[0].Id); err != nil {
+			return err
+		}
 	}
 
 	return c.SaveContextConfig(config.DefaultConfigFilePath)

--- a/pkg/handlers/user/login.go
+++ b/pkg/handlers/user/login.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aserto-dev/aserto/pkg/auth0/api"
 	"github.com/aserto-dev/aserto/pkg/auth0/device"
 	"github.com/aserto-dev/aserto/pkg/cc"
 	"github.com/aserto-dev/aserto/pkg/clients/tenant"
@@ -47,61 +48,98 @@ func (d *LoginCmd) Run(c *cc.CommonCtx) error {
 		fmt.Printf("Open browser %s\n", flow.GetVerificationURI())
 	}
 
-	{ // intentionally scoped.
-		ctx, cancel := context.WithTimeout(c.Context, flow.ExpiresIn())
-		defer cancel()
+	ctx, cancel := context.WithTimeout(c.Context, flow.ExpiresIn())
+	defer cancel()
 
-		for {
-			if ok, err := flow.RequestAccessToken(ctx); ok {
-				fmt.Fprintln(c.StdOut(), ".")
-				break
-			} else if err != nil {
-				return err
-			}
+	for {
+		if ok, err := flow.RequestAccessToken(ctx); ok {
+			fmt.Fprintln(c.StdOut(), ".")
+			break
+		} else if err != nil {
+			return err
+		}
 
-			select {
-			case <-time.After(flow.Interval()):
-				fmt.Fprint(c.StdOut(), ".")
-			case <-ctx.Done():
-				return errors.New("canceled")
-			}
+		select {
+		case <-time.After(flow.Interval()):
+			fmt.Fprint(c.StdOut(), ".")
+		case <-ctx.Done():
+			return errors.New("canceled")
 		}
 	}
 
-	token := flow.AccessToken()
-
-	{ // intentionally scoped.
-		ctx, cancel := context.WithTimeout(c.Context, time.Second*10)
-		defer cancel()
-
-		conn, err := tenant.NewClient(
-			ctx,
-			client.WithAddr(c.Environment.TenantService.Address),
-			client.WithTokenAuth(token.Access),
-		)
-		if err != nil {
-			return err
-		}
-
-		if err = getTenantID(ctx, conn, token); err != nil {
-			return errors.Wrapf(err, "get tenant id")
-		}
-
-		if err = GetConnectionKeys(ctx, conn, token); err != nil {
-			return errors.Wrapf(err, "get connection keys")
-		}
-
-		kr, err := keyring.NewKeyRing(c.Auth.Issuer)
-		if err != nil {
-			return err
-		}
-
-		if err := kr.SetToken(token); err != nil {
-			return err
-		}
-
-		fmt.Fprintln(c.StdOut(), "Login successful")
+	if err := UpdateKeyRing(c, flow.AccessToken()); err != nil {
+		return err
 	}
+
+	c.Con().Info().Msg("Login successful")
+
+	return nil
+}
+
+func UpdateKeyRing(c *cc.CommonCtx, token *api.Token) error {
+	ctx, cancel := context.WithTimeout(c.Context, time.Second*10)
+	defer cancel()
+
+	conn, err := tenant.NewClient(
+		ctx,
+		client.WithAddr(c.Environment.TenantService.Address),
+		client.WithTokenAuth(token.Access),
+	)
+	if err != nil {
+		return err
+	}
+
+	if err = getTenantID(ctx, conn, token); err != nil {
+		return errors.Wrapf(err, "get tenant id")
+	}
+
+	if err = GetConnectionKeys(ctx, conn, token); err != nil {
+		return errors.Wrapf(err, "get connection keys")
+	}
+
+	kr, err := keyring.NewKeyRing(c.Auth.Issuer)
+	if err != nil {
+		return err
+	}
+
+	if err := kr.SetToken(token); err != nil {
+		return err
+	}
+
+	c.Con().Info().Msg("Switched to tenant-id %q", c.TenantID())
+
+	return nil
+}
+
+func SwitchKeyRing(c *cc.CommonCtx, token *api.Token, tenantID string) error {
+	ctx, cancel := context.WithTimeout(c.Context, time.Second*10)
+	defer cancel()
+
+	conn, err := tenant.NewClient(
+		ctx,
+		client.WithAddr(c.Environment.TenantService.Address),
+		client.WithTokenAuth(token.Access),
+	)
+	if err != nil {
+		return err
+	}
+
+	token.TenantID = tenantID
+
+	if err = GetConnectionKeys(ctx, conn, token); err != nil {
+		return errors.Wrapf(err, "get connection keys")
+	}
+
+	kr, err := keyring.NewKeyRing(c.Auth.Issuer)
+	if err != nil {
+		return err
+	}
+
+	if err := kr.SetToken(token); err != nil {
+		return err
+	}
+
+	c.Con().Info().Msg("Switched to tenant-id %q", c.TenantID())
 
 	return nil
 }

--- a/pkg/handlers/user/props.go
+++ b/pkg/handlers/user/props.go
@@ -29,7 +29,11 @@ func (cmd *GetCmd) Run(c *cc.CommonCtx) error {
 	case "access-token":
 		propValue, err = c.AccessToken()
 	case "tenant-id":
-		propValue = c.TenantID()
+		token, tokenErr := c.Token()
+		if tokenErr != nil {
+			return tokenErr
+		}
+		propValue = token.TenantID
 	case "authorizer-key":
 		propValue, err = c.AuthorizerAPIKey()
 	case "directory-read-key":


### PR DESCRIPTION
The token and related key values were not correctly updated when switching between tenants using `aserto config use`. This PR removes the redundant tenant ID property on the client factory and moves the TenantID() function from the Factory interface to the CommonCtx, source from the token instead of the factory property.
